### PR TITLE
Redirect problem.

### DIFF
--- a/includes/class.WCGatewayDotpay.php
+++ b/includes/class.WCGatewayDotpay.php
@@ -169,8 +169,10 @@
                         $data = $_POST;
                         $order = new WC_Order($data['control']);
                         
-                        if($_SERVER['REMOTE_ADDR'] <> self::DOTPAY_IP)
+                        if($_SERVER['REMOTE_ADDR'] <> self::DOTPAY_IP){
                                 wp_redirect( $this->get_return_url( $order ) );
+				exit();
+			}
 
                         $data["dotpay_pin"] = $this->get_option('dotpay_pin');
                         if(!$this->check_urlc_legacy($data))


### PR DESCRIPTION
In WordPress "wp_redirect" function need to be used with the "exit" function. If is not it redirect page but the code after is excuted.
In "check_dotpay_response_legacy" function after checking the Dotpay ID. If its wrong it gets redirection but also for example continue to changing order statuses.

At my page which was using CloudFlare. Dotpay response comes with the cloudeflare IP instead of the Dotpay ID. All orders information which come from the Dotpay to the system change WooCommerce order statuses but also wasn't satisfied by the "OK" answer. So it continues to send the same information again and again. It also get some other isusses for example if firstly payment was refused but another payment was accepted. In this situation. Orders get statuses Completed and Refused alternately.

This was only my case but this problem could be bigger if someone will start to send POSTs from other IP but will could change Order statuses

Regards,
Michał Strześniewski